### PR TITLE
Add css battle discussion category template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -4,7 +4,7 @@ body:
   - type: input
     id: link
     attributes:
-      label: Link to battle
+      label: "Link to battle:"
       description: Replace NUMBER with current battle number      
       value: |
        [Lets battle! ⚔️](https://cssbattle.dev/play/NUMBER)
@@ -17,7 +17,7 @@ body:
         **Please note:** Don't change text areas - they need to stay that way to be visible after creating discussion
   - type: textarea
     attributes:
-      label:  "Let's see your solutions! When posting your answers, you can save members from being spoiled by using the code block below to format your comment on the discussion thread:"
+      label:  "Copy the code block below to format your comment on the discussion thread:"
       description: Solution template for players
       value: |
         ```html
@@ -36,7 +36,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: What others will see
+      label: "What others will see:"
       description: Solution preview
       value: |
         This will result in a nice hidden bit like so:<br />

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -17,7 +17,7 @@ body:
         **Please note:** Don't change text areas - they need to stay that way to be visible after creating discussion
   - type: textarea
     attributes:
-      label: Let's see the solutions! - copy code and paste into your msg
+      label:  "Let's see your solutions! When posting your answers, you can save members from being spoiled by using the code block below to format your comment on the discussion thread:"
       description: Solution template for players
       value: |
         ```html

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -58,7 +58,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: Is battle link number and battle title number the same?
+      label: Are battle link number and battle title number the same?
       options:
         - label: "Yes"
           required: true

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -32,7 +32,7 @@ body:
   - type: textarea
     attributes:
       label: What others will see
-      description: Solution showcase
+      description: Solution preview
       value: |
         This will result in a nice hidden bit like so:<br />
         <details>

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -1,4 +1,4 @@
-title: "CSS Battle #<number> – <Problem Name>"
+title: "CSS Battle #NUMBER – NAME"
 labels: ["CSS Battles"]
 body:
   - type: input
@@ -7,7 +7,7 @@ body:
       label: Link to battle
       description: Replace number with current battle number      
       value: |
-       [Lets battle! ⚔️](https://cssbattle.dev/play/number)
+       [Lets battle! ⚔️](https://cssbattle.dev/play/NUMBER)
     validations:
       required: true
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -2,56 +2,63 @@ title: "CSS Battle #<number> – <Problem Name>"
 labels: ["CSS Battles"]
 body:
   - type: input
-    id: number
+    id: link
     attributes:
-      label: Problem Number
-      description: The number of the problem being discussed (in digits)
-      placeholder: Problem number
+      label: Link to battle
+      description: Replace number with current battle number
+      placeholder: https//cssbatle.dev/play/number
+      value: |
+       [Lets battle! ⚔️](https://cssbattle.dev/play/number)
     validations:
       required: true
-  - type: input
-    id: name
+  - type: textarea
     attributes:
-      label: Problem Name
-      description: The name of the problem being discussed
-      placeholder: Problem name
-    validations:
-      required: true
-  - type: markdown
-    attributes:
-      value: |
-        Here is the puzzle: https://cssbattle.dev/play/<number>
-
-        Let's see the solutions!
-  - type: markdown
-    attributes:
-      value: <hr />
-  - type: markdown
-    attributes:
-      value: "## Sharing Your Solutions"
-  - type: markdown
-    attributes:
-      value: |
-        When posting your answers, you can save members from being spoiled by wrapping your code in the following:
-
-            <details>
-            <summary>Description – <strong>score {characters}</strong></summary><br />
-            <!-- Has to be followed by an empty line! -->
-
-            ```html
-            Your CSSBattles.dev code here!
-            ```
-            </details>
-
-        This will result in a nice hidden bit like so:
-
+      label: Let's see the solutions! - copy code and paste into your msg
+      description: Solution template for players
+      placeholder: |
+        ```html
         <details>
         <summary>Description – <strong>score {characters}</strong></summary><br />
         <!-- Has to be followed by an empty line! -->
 
-        ```html
-        Your CSSBattles.dev code here!
-        ```
-        </details>
+        <!-- remove + character -->
+        +```html
+        Your CSSBattles.dev code here! ⚔️
+        +```
 
-        Feel free to copy/paste the above code into a comment!
+        </details>
+        ```
+      value: |
+        ```html
+        <details>
+        <summary>Description – <strong>score {characters}</strong></summary><br />
+        <!-- Has to be followed by an empty line! -->
+
+        <!-- remove + character -->
+        +```html
+        Your CSSBattles.dev code here! ⚔️
+        +```
+
+        </details>
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What others will see
+      description: Solution showcase
+      value: |
+        This will result in a nice hidden bit like so:<br />
+        <details>
+        <summary>Description – <strong>score {characters}</strong></summary><br />
+        Your CSSBattles.dev code here! ⚔️
+        </details>
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Is battle link number and battle title number the same?
+      options:
+        - label: "Yes"
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -5,11 +5,16 @@ body:
     id: link
     attributes:
       label: Link to battle
-      description: Replace number with current battle number      
+      description: Replace NUMBER with current battle number      
       value: |
        [Lets battle! ⚔️](https://cssbattle.dev/play/NUMBER)
     validations:
       required: true
+  - type: markdown
+    attributes: 
+      value: |
+        **That’s all! You can now click the “Start discussion” button.** :smile:
+        **Please note:** Don't change text areas - they need to stay that way to be visible after creating discussion
   - type: textarea
     attributes:
       label: Let's see the solutions! - copy code and paste into your msg

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -5,8 +5,7 @@ body:
     id: link
     attributes:
       label: Link to battle
-      description: Replace number with current battle number
-      placeholder: https//cssbatle.dev/play/number
+      description: Replace number with current battle number      
       value: |
        [Lets battle! ⚔️](https://cssbattle.dev/play/number)
     validations:
@@ -15,19 +14,6 @@ body:
     attributes:
       label: Let's see the solutions! - copy code and paste into your msg
       description: Solution template for players
-      placeholder: |
-        ```html
-        <details>
-        <summary>Description – <strong>score {characters}</strong></summary><br />
-        <!-- Has to be followed by an empty line! -->
-
-        <!-- remove + character -->
-        +```html
-        Your CSSBattles.dev code here! ⚔️
-        +```
-
-        </details>
-        ```
       value: |
         ```html
         <details>

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -55,10 +55,3 @@ body:
         </details>
     validations:
       required: true
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Are battle link number and battle title number the same?
-      options:
-        - label: "Yes"
-          required: true


### PR DESCRIPTION
## Linked Issue
https://github.com/Virtual-Coffee/virtualcoffee.io/issues/900

## Description
Change discussion template for posts about CSS Battles on Virtual Coffee discussion forums
@meg-gutshall 

## Methodology

### Currently used template when creating discussion:
| creating discussion | discussion look |
|:-------:|-------|
|<img src="https://i.imgur.com/JnL65P8.png" width="300"> | <img src="https://i.imgur.com/Jm3F2O5.png" width="300">|

### Proposed changes
| creating discussion | discussion look |
|:-------:|-------|
|<img src="https://i.imgur.com/IdOeOWE.png" width="300"> | <img src="https://i.imgur.com/YEfnjHo.png" width="300">|

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)